### PR TITLE
CRUD tests

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 
 export default defineConfig({
+  projectId: "un86wj",
   videosFolder: 'projects/angular-ngrx-material-starter/cypress/videos',
   screenshotsFolder:
     'projects/angular-ngrx-material-starter/cypress/screenshots',

--- a/projects/angular-ngrx-material-starter/cypress/integration/books.cy.ts
+++ b/projects/angular-ngrx-material-starter/cypress/integration/books.cy.ts
@@ -1,0 +1,45 @@
+var bookTitle = 'Atlas Shrugged';
+var bookAuthor = 'Ayn Rand';
+var bookDescription = 'Who is John Galt?';
+var firstBookTitle = 'Reactive Programming with Angular and ngrx';
+var firstBookAuthor = 'Oren Farhi';
+var firstBookDescription = 'Learn to Harness the Power of Reactive Programming with RxJS and ngrx Extensions'
+
+describe('CRUD Library', () => {
+  beforeEach(() => {
+    cy.visit('/examples/crud')
+  })
+
+  it('should allow user to read existing entry', () => {
+    cy.verifyFirstBook(firstBookTitle, firstBookAuthor);
+  });
+
+  it('should allow user to read existing entry on mobile', () => {
+    cy.viewport('iphone-x')
+      .verifyFirstBook(firstBookTitle, firstBookAuthor);
+  });
+
+  it('should allow user to create a new entry', () => {
+    cy.createBook(bookTitle, bookAuthor, bookDescription)
+      .verifyFirstBook(bookTitle, bookAuthor)
+      .verifyBookDetails(bookTitle, bookAuthor, bookDescription);
+  });
+
+  it('should allow user to update existing entry', () => {
+    var updatedTitle = 'High Fidelity';
+    var updatedAuthor = 'Nick Hornby';
+    var updatedDescription = 'An obsessive music fan who examines his top ' +
+      'five worst break ups to understand his most recent heartbreak.';
+    cy.createBook(bookTitle, bookAuthor, bookDescription)
+      .get('[data-icon="edit"]').click()
+      .addBookDetails(updatedTitle, updatedAuthor, updatedDescription)
+      .verifyFirstBook(updatedTitle, updatedAuthor)
+      .verifyBookDetails(updatedTitle, updatedAuthor, updatedDescription);
+  });
+
+  it('should allow user to delete existing entry', () => {
+    cy.createBook(bookTitle, bookAuthor, bookDescription)
+      .get('[data-icon="trash"]').click()
+      .verifyFirstBook(firstBookTitle, firstBookAuthor);
+  });
+});

--- a/projects/angular-ngrx-material-starter/cypress/integration/books.cy.ts
+++ b/projects/angular-ngrx-material-starter/cypress/integration/books.cy.ts
@@ -11,17 +11,17 @@ describe('CRUD Library', () => {
   })
 
   it('should allow user to read existing entry', () => {
-    cy.verifyFirstBook(firstBookTitle, firstBookAuthor);
+    cy.verifyBook(firstBookTitle, firstBookAuthor);
   });
 
   it('should allow user to read existing entry on mobile', () => {
     cy.viewport('iphone-x')
-      .verifyFirstBook(firstBookTitle, firstBookAuthor);
+      .verifyBook(firstBookTitle, firstBookAuthor);
   });
 
   it('should allow user to create a new entry', () => {
     cy.createBook(bookTitle, bookAuthor, bookDescription)
-      .verifyFirstBook(bookTitle, bookAuthor)
+      .verifyBook(bookTitle, bookAuthor)
       .verifyBookDetails(bookTitle, bookAuthor, bookDescription);
   });
 
@@ -33,13 +33,13 @@ describe('CRUD Library', () => {
     cy.createBook(bookTitle, bookAuthor, bookDescription)
       .get('[data-icon="edit"]').click()
       .addBookDetails(updatedTitle, updatedAuthor, updatedDescription)
-      .verifyFirstBook(updatedTitle, updatedAuthor)
+      .verifyBook(updatedTitle, updatedAuthor)
       .verifyBookDetails(updatedTitle, updatedAuthor, updatedDescription);
   });
 
   it('should allow user to delete existing entry', () => {
     cy.createBook(bookTitle, bookAuthor, bookDescription)
       .get('[data-icon="trash"]').click()
-      .verifyFirstBook(firstBookTitle, firstBookAuthor);
+      .verifyBook(firstBookTitle, firstBookAuthor);
   });
 });

--- a/projects/angular-ngrx-material-starter/cypress/support/commands.ts
+++ b/projects/angular-ngrx-material-starter/cypress/support/commands.ts
@@ -54,7 +54,7 @@ Cypress.Commands.add('addBookDetails', (bookTitle, bookAuthor, bookDescription) 
     cy.get('.mat-primary > .mat-button-wrapper').click();
 })
 
-Cypress.Commands.add('verifyFirstBook', (bookTitle, bookAuthor) => {
+Cypress.Commands.add('verifyBook', (bookTitle, bookAuthor) => {
     cy.get('[class="row"]').contains('h3', bookTitle);
     cy.get('[class="row"]').contains('small', bookAuthor);
 })

--- a/projects/angular-ngrx-material-starter/cypress/support/commands.ts
+++ b/projects/angular-ngrx-material-starter/cypress/support/commands.ts
@@ -41,3 +41,26 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+
+Cypress.Commands.add('createBook', (bookTitle, bookAuthor, bookDescription) => {
+    cy.get('.add').click()
+      .addBookDetails(bookTitle, bookAuthor, bookDescription);
+})
+
+Cypress.Commands.add('addBookDetails', (bookTitle, bookAuthor, bookDescription) => {
+    cy.get('[data-placeholder="Title"]').clear().type(bookTitle);
+    cy.get('[data-placeholder="Author"]').clear().type(bookAuthor);
+    cy.get('[data-placeholder="Description"]').clear().type(bookDescription);
+    cy.get('.mat-primary > .mat-button-wrapper').click();
+})
+
+Cypress.Commands.add('verifyFirstBook', (bookTitle, bookAuthor) => {
+    cy.get('[class="row"]').contains('h3', bookTitle);
+    cy.get('[class="row"]').contains('small', bookAuthor);
+})
+
+Cypress.Commands.add('verifyBookDetails', (bookTitle, bookAuthor, bookDescription) => {
+    cy.get(':nth-child(2) > .route-animations-elements.ng-star-inserted > h3').contains(bookTitle);
+    cy.get('p').contains(bookDescription);
+    cy.get('i').contains(bookAuthor);
+})

--- a/projects/angular-ngrx-material-starter/cypress/support/index.ts
+++ b/projects/angular-ngrx-material-starter/cypress/support/index.ts
@@ -14,4 +14,9 @@
 // ***********************************************************
 
 // When a command from ./commands is ready to use, import with `import './commands'` syntax
-// import './commands';
+import './commands';
+
+Cypress.SelectorPlayground.defaults({
+    selectorPriority: ['data-placeholder', 'data-icon', 'id', 'class', 
+        'attributes'],
+})


### PR DESCRIPTION
**Design choices**

- I chose to create custom commands for tasks that were repetitive and used in multiple tests. There is a tendency with Cypress to use Page Objects as many people are familiar doing with Selenium but one of the tenets of Cypress is to keep things simple which is why I chose not to create a method like “editBook()” which would only be one line of code and is only used in one test. If I were to create additional test cases that exercised editing a book it may be a candidate for creating a custom command but opted for less unnecessary overhead. 
- I noticed that there were useful tags such as “data-placeholder” and “data-icon” that could be used to find elements. In order for the Cypress Selector Playground to find them, I added them to a customized priority list.
- I configured a new project in my personal Cypress account to receive results from the tests. The projectId has been added to this PR and you can see results here: https://cloud.cypress.io/projects/un86wj/runs/1/overview. A new test result can be achieved by running the following command which contains my project key:

npx cypress run --record --key bcb1bacc-5c3b-4340-a32f-c74b7107c65e

**Possible further actions**

- Additional viewports could be setup in addition to the 'iphone-x' test I included. This would be useful to test a variety of devices for potential visual or functional issues. Ideally you could use one test and loop through various viewports dynamically creating new tests.
- Negative test case scenarios would also be helpful to understand if the application gives users the proper errors (i.e. title and author are required fields which should give users errors when left blank, inputs should be tested for maximum characters allowed)
- Cypress gives you the option to mock API endpoints. It would be useful if the application read book entries from an API so that test cases where multiple books are displayed could be mocked without having to enter in several books through the UI to look for any formatting issues.
- Reporting test results to Elasticsearch would also be useful to create visualizations in Kibana. Keeping track of test health and other statistics is important for maintenance of the test solution. Using a package like [mocha-elk-reporter](https://www.npmjs.com/package/mocha-elk-reporter) makes this easy. I did not implement this in this example.
- Parallelization of the tests would help reduce test time. As the tests grow, this would be helpful. Cypress provides an option to do parallelization. Using tools like AWS Lamdba would also be an option.
- These test cases only verify the functionality of the application. Another way to test it would be to run visual tests and take screenshots of the application in various states to make sure that visually the application functions as expected. You can compare screenshots using a third party product like Applitools. Ideally you'd compare the feature branch to the live version of the site and make sure any differences were expected.
- Accessibility testing could also be done to help ensure the application can be used by as many people as possible.
